### PR TITLE
Dockerize build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Unclear if this image is the best choice
+FROM openjdk:17-slim
+
+RUN apt-get update && apt-get install -y \
+    maven \
+    gettext-base \
+    && rm -rf /var/lib/apt/lists/*
+# Not sure if the two latter are needed
+
+WORKDIR /app
+
+COPY pom.xml build_and_copy.sh .
+COPY src ./src
+
+# Make the script executable
+RUN chmod +x build_and_copy.sh
+
+# Set the entrypoint to the shell script
+ENTRYPOINT ["./build_and_copy.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# claudeapi
+
+## Building with Docker
+To build the code fully with Docker, perform the following steps:
+
+1. Create some output destination for the compiled files. I recommend a Docker-managed volume.
+2. Build the Docker image using `docker build -t <my-image-name> .`.
+3. Run the build process using `docker run --rm -v <build-destination>:/output <my-image-name>`.
+
+The built files should now be found at `<build-destination>/claudeapi`.

--- a/build_and_copy.sh
+++ b/build_and_copy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+mvn clean package -DskipTests
+
+if [ $? -eq 0 ]; then
+  if [ ! -d "/output/claudeapi" ]; then
+    mkdir -p "/output/claudeapi"
+  fi
+    
+  cp target/*.jar /output/claudeapi/
+  cp pom.xml /output/claudeapi/
+  echo "Build and copy successful."
+else
+  echo "Build failed."
+  exit 1 # Exit with an error code
+fi


### PR DESCRIPTION
Add a Dockerfile and build scripts to make the library fully buildable inside a Docker container. The changes should be familiar.